### PR TITLE
Resolving conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Future releases can be built from source, but pip will contain the most recent s
 
 ## Contributing
 
-Please refer to the World Bank's Github [Contributing](docs/Contributing.md) guidelines.
+Please refer to the World Bank's Github [Contributing](docs/CONTRIBUTING.md) guidelines.
 
 ## Code of Conduct
 

--- a/src/GOSTrocks/ghslMisc.py
+++ b/src/GOSTrocks/ghslMisc.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 import matplotlib.pyplot as plt
 
-from GOSTRocks.misc import tPrint
+from GOSTrocks.misc import tPrint
 
 curPath = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
 if not curPath in sys.path:

--- a/src/GOSTrocks/osmMisc.py
+++ b/src/GOSTrocks/osmMisc.py
@@ -5,7 +5,7 @@ import osmnx as ox
 import pandas as pd
 
 from shapely.geometry import box
-from GOSTRocks import misc
+from GOSTrocks import misc
 
 # Highway features are reclassified to 4 OSMLR classes for simplification and standardization
 #   https://mapzen.com/blog/osmlr-2nd-technical-preview/

--- a/src/GOSTrocks/rasterMisc.py
+++ b/src/GOSTrocks/rasterMisc.py
@@ -16,9 +16,6 @@ from rasterio.merge import merge
 from rasterio.io import MemoryFile
 from contextlib import contextmanager
 
-import seaborn as sns
-sns.set(font_scale=1.5, style="whitegrid")
-
 curPath = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
 if not curPath in sys.path:
     sys.path.append(curPath)

--- a/src/GOSTrocks/rasterMisc.py
+++ b/src/GOSTrocks/rasterMisc.py
@@ -136,7 +136,7 @@ def project_raster(srcRst, dstCrs, output_raster=''):
 
     return([dstRst, kwargs])
          
-def clipRaster(inR, inD, outFile='', crop=True):
+def clipRaster(inR, inD, outFile=None, crop=True):
     ''' Clip input raster
     
     :param inR: rasterio object to clip
@@ -163,12 +163,12 @@ def clipRaster(inR, inD, outFile='', crop=True):
         tD = gpd.GeoDataFrame([[1]], geometry=[box(*inD.total_bounds)])
     
     coords = getFeatures(tD)
-    out_img, out_transform = mask(inR, shapes=coords, crop=True)
+    out_img, out_transform = mask(inR, shapes=coords, crop=True, all_touched=True)
     out_meta.update({"driver": "GTiff",
                      "height": out_img.shape[1],
                      "width": out_img.shape[2],
                      "transform": out_transform})
-    if outFile != '':
+    if outFile:
         with rasterio.open(outFile, "w", **out_meta) as dest:
             dest.write(out_img)
     return([out_img, out_meta])


### PR DESCRIPTION
Resolving conflicts from working on a separate fork over the past months/years:
-  `clipRaster` was creating a strip of no data at the bottom which always needed to be cleaned. Added `all_touched=True` to `rasterio.mask` to fix this.
- Added explicit handling of nodata to `rasterizeDataFrame`. By default `np.nan` but user needs to set depending on the data type.
- Function to get UTM zone for a given `GeoDataFrame`: `get_utm()`
- Small fixes to import statements.
- Repo has been renamed to GOSTrocks following https://github.com/worldbank/GOSTnetsraster/issues/10
- Recreated the repo using WB template

These should not break anything but wanted to give you a heads-up. 
Will work on some basic docs that explain the most important functions next and reuploading to pypi.

@bpstewar @g4brielvs @elbeejay